### PR TITLE
[WIP] retry jobs

### DIFF
--- a/docs/sphinx/spack-pipeline-feature.rst
+++ b/docs/sphinx/spack-pipeline-feature.rst
@@ -224,7 +224,7 @@ Issues and workarounds
 Random failures
 ---------------
 
-Sometimes, some jobs will fails for reasons that have not been explored yet,
+Sometimes, some jobs will fail for reasons that have not been explored yet,
 mainly because those bugs are not reproducible.
 
 As an example:

--- a/docs/sphinx/spack-pipeline-feature.rst
+++ b/docs/sphinx/spack-pipeline-feature.rst
@@ -218,6 +218,33 @@ making them specific to that instance by design:
    that would otherwise consist in the merge of all the scopes.
 
 
+Issues and workarounds
+======================
+
+Random failures
+---------------
+
+Sometimes, some jobs will fails for reasons that have not been explored yet,
+mainly because those bugs are not reproducible.
+
+As an example:
+
+.. code-block:: bash
+   ==> [2021-08-04-07:14:33.660115] Copying build log ([...]/spack-build-out.txt) to artifacts ([...]/spack-build-out.txt)
+   ==> [2021-08-04-07:14:33.662652] Error: Unable to copy build logs from stage to artifacts due to exception: [Errno 2] No such file or directory: '[...]/spack-build    -out.txt'
+   ==> [2021-08-04-07:14:33.662744] spack install exited non-zero, will not create buildcach
+
+To work around this, we ask Gitlab to retry jobs twice before giving up.
+
+.. literalinclude:: ../../spack-environments/radiuss/spack.yaml
+   :start-after: [retry-on-script-failure--]
+   :end-before: [--retry-on-script-failure]
+
+.. note::
+   We restrict retrying a job to script failure so that we don't unnecessarily
+   stress the system when the failure comes from a system issue.
+
+
 Future works
 ============
 

--- a/spack-environments/radiuss/spack.yaml
+++ b/spack-environments/radiuss/spack.yaml
@@ -89,7 +89,11 @@ spack:
           - . ${CHILD_SPACK_PATH}/share/spack/setup-env.sh
           - cd ${SPACK_CONCRETE_ENV_DIR} && spack env activate --without-view .
           - spack -d ci rebuild
-          retry: 3
+          # [retry-on-script-failure--]
+          retry:
+            max: 2
+            when: script_failure
+          # [--retry-on-script-failure]
 
       # lassen
       - match:
@@ -102,7 +106,9 @@ spack:
           #[--child-variables]
           - cd ${SPACK_CONCRETE_ENV_DIR} && spack env activate --without-view .
           - spack -d ci rebuild
-          retry: 3
+          retry:
+            max: 2
+            when: script_failure
 
     service-job-attributes:
       tags: [quartz, shell]

--- a/spack-environments/radiuss/spack.yaml
+++ b/spack-environments/radiuss/spack.yaml
@@ -89,6 +89,7 @@ spack:
           - . ${CHILD_SPACK_PATH}/share/spack/setup-env.sh
           - cd ${SPACK_CONCRETE_ENV_DIR} && spack env activate --without-view .
           - spack -d ci rebuild
+          retry: 3
 
       # lassen
       - match:
@@ -101,6 +102,8 @@ spack:
           #[--child-variables]
           - cd ${SPACK_CONCRETE_ENV_DIR} && spack env activate --without-view .
           - spack -d ci rebuild
+          retry: 3
+
     service-job-attributes:
       tags: [quartz, shell]
       before_script:


### PR DESCRIPTION
Sometimes jobs fail but pass when hitting "retry". We try to workaround this by allowing retrying a job automatically on script failure.
This is not ideal, but gives us confidence that failures are really due to a problem with a build, rather than a random failure.

Ideally, the random failure should be addressed.