### PR TITLE
This is an ugly hack to fix permissions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,11 +18,11 @@ variables:
 # We only do one generation per stage because we found conflicts otherwise
 #[one-generate-per-stage--]
 stages:
-  - get-spack
+  - first
   - generate-quartz
   - generate-lassen
   - build
-  - rm-spack
+  - last
 #[--one-generate-per-stage]
 
 .on-quartz:
@@ -34,7 +34,7 @@ stages:
 #[get-spack--]
 get-spack:
   extends: [.on-quartz]
-  stage: get-spack
+  stage: first
   script:
     - scripts/get-spack
 #[--get-spack]
@@ -42,10 +42,20 @@ get-spack:
 #[rm-spack--]
 rm-spack:
   extends: [.on-quartz]
-  stage: rm-spack
+  stage: last
   script:
     - scripts/remove-spack
 #[--rm-spack]
+
+# Ugly hack to allow someone else to write in the install dir.
+# The issue is that .spack-db/index.json and ohers have permissions restricted
+# to the owner.
+fix-permissions:
+  extends: [.on-quartz]
+  stage: last
+  script:
+    - chmod -R g+rwX /usr/workspace/radiuss/install/radiuss-stack/spack_path_placeholder/spack_path_placeholder/spack_path_placeholder/spack_path_pla/spack-db
+  when: always
 
 include:
   - .gitlab/generate.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ fix-permissions:
   extends: [.on-quartz]
   stage: last
   script:
-    - chmod -R g+rwX /usr/workspace/radiuss/install/radiuss-stack/spack_path_placeholder/spack_path_placeholder/spack_path_placeholder/spack_path_pla/spack-db
+    - chmod -R g+rwX /usr/workspace/radiuss/install/radiuss-stack/spack_path_placeholder/spack_path_placeholder/spack_path_placeholder/spack_path_pla/.spack-db
   when: always
 
 include:


### PR DESCRIPTION
This is an attempt to always end a pipeline with correct permissions in the spack mirror.