### PR TITLE
Merge config with radiuss-spack-config one

### DIFF
--- a/spack-environments/radiuss/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/spack-environments/radiuss/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -46,6 +46,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@11.0.0
+    paths:
+      cc: /usr/tce/packages/clang/clang-11.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-11.0.0/bin/clang++
+      f77: /usr/tce/packages/xl/xl-beta-2019.06.20/bin/xlf2003_r
+      fc: /usr/tce/packages/xl/xl-beta-2019.06.20/bin/xlf2003_r
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@9.0.0ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang
@@ -65,6 +78,19 @@ compilers::
       cxx: /usr/tce/packages/clang/clang-ibm-10.0.1/bin/clang++
       fc: /usr/tce/packages/xl/xl-2020.09.17/bin/xlf2003_r
       f77: /usr/tce/packages/xl/xl-2020.09.17/bin/xlf_r
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@11.0.0ibm
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2020.11.12/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2020.11.12/bin/xlf_r
     flags: {}
     operating_system: rhel7
     target: ppc64le

--- a/spack-environments/radiuss/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/spack-environments/radiuss/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -17,7 +17,16 @@ packages::
     # us to run on broadwell as well
     target: [ppc64le]
     compiler: [gcc, pgi, clang, xl]
-
+  cmake:
+    version: [3.18.0, 3.20.2, 3.14.5]
+    buildable: false
+    externals:
+    - spec: cmake@3.14.5
+      prefix: /usr/tce/packages/cmake/cmake-3.14.5
+    - spec: cmake@3.18.0
+      prefix: /usr/tce/packages/cmake/cmake-3.18.0
+    - spec: cmake@3.20.2
+      prefix: /usr/tce/packages/cmake/cmake-3.20.2
   cuda:
     version: [11.0.2, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
@@ -53,14 +62,6 @@ packages::
     - spec: spectrum-mpi@10.3.1.03rtm0%xl@beta2019.06.20
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-beta-2019.06.20
     buildable: false
-
-  cmake:
-    version: [3.18.0]
-    buildable: false
-    externals:
-    - spec: cmake@3.18.0
-      prefix: /usr/tce/packages/cmake/cmake-3.18.0
-
   python:
     buildable: false
     version: [3.8.2]
@@ -75,13 +76,6 @@ packages::
     externals:
     - spec: netlib-lapack@3.9.0
       prefix: /usr/tcetmp/packages/lapack/lapack-3.9.0-P9-xl-2020.03.18
-
-#   # Blas/Lapack virtual package provider
-#   netlib-lapack:
-#     buildable: false
-#     externals:
-#     - spec: netlib-lapack@3.6.1
-#       prefix: /usr
 
   #ncurses has a bug in their 6.2 that says that getopt is not present
   # see: https://github.com/spack/spack/issues/16269

--- a/spack-environments/radiuss/toss_3_x86_64_ib/compilers.yaml
+++ b/spack-environments/radiuss/toss_3_x86_64_ib/compilers.yaml
@@ -7,6 +7,71 @@
 
 compilers::
 - compiler:
+    spec: clang@3.9.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-3.9.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-3.9.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@4.0.0
+    paths:
+      cc: /usr/tce/packages/clang/clang-4.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-4.0.0/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@6.0.0
+    paths:
+      cc: /usr/tce/packages/clang/clang-6.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-6.0.0/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@9.0.0
+    paths:
+      cc: /usr/tce/packages/clang/clang-9.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-9.0.0/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@10.0.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-10.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-10.0.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     environment: {}
     extra_rpaths: []
     flags:
@@ -22,6 +87,217 @@ compilers::
       fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
     spec: clang@10.0.0
     target: x86_64
+- compiler:
+    spec: gcc@4.9.3
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-4.9.3/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@16.0.4
+    paths:
+      cc: /usr/tce/packages/intel/intel-16.0.4/bin/icc
+      cxx: /usr/tce/packages/intel/intel-16.0.4/bin/icpc
+      f77: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
+      fc: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/g++
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@17.0.2
+    paths:
+      cc: /usr/tce/packages/intel/intel-17.0.2/bin/icc
+      cxx: /usr/tce/packages/intel/intel-17.0.2/bin/icpc
+      f77: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
+      fc: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/g++
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@18.0.0
+    paths:
+      cc: /usr/tce/packages/intel/intel-18.0.0/bin/icc
+      cxx: /usr/tce/packages/intel/intel-18.0.0/bin/icpc
+      f77: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
+      fc: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@18.0.2
+    paths:
+      cc: /usr/tce/packages/intel/intel-18.0.2/bin/icc
+      cxx: /usr/tce/packages/intel/intel-18.0.2/bin/icpc
+      f77: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
+      fc: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.0.4
+    paths:
+      cc: /usr/tce/packages/intel/intel-19.0.4/bin/icc
+      cxx: /usr/tce/packages/intel/intel-19.0.4/bin/icpc
+      f77: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
+      fc: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.1.0
+    paths:
+      cc: /usr/tce/packages/intel/intel-19.1.0/bin/icc
+      cxx: /usr/tce/packages/intel/intel-19.1.0/bin/icpc
+      f77: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
+      fc: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@17.10
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-17.10/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-17.10/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-17.10/bin/pgf77
+      fc: /usr/tce/packages/pgi/pgi-17.10/bin/pgf95
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@18.5
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-18.5/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-18.5/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-18.5/bin/pgf77
+      fc: /usr/tce/packages/pgi/pgi-18.5/bin/pgf95
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@19.4
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-19.4/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-19.4/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-19.4/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-19.4/bin/pgfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@19.7
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-19.7/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-19.7/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-19.7/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-19.7/bin/pgf95
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@20.1
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-20.1/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-20.1/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-20.1/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-20.1/bin/pgf95
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@6.1.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-6.1.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.1.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.3.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
 - compiler:
     environment: {}
     extra_rpaths: []

--- a/spack-environments/radiuss/toss_3_x86_64_ib/packages.yaml
+++ b/spack-environments/radiuss/toss_3_x86_64_ib/packages.yaml
@@ -24,23 +24,43 @@ packages::
       unwind:
       - libunwind
 
+    # This defaults us to machine specific flags of ivybridge which allows
+    # us to run on broadwell as well
+    target: [ivybridge]
+    compiler: [gcc, intel, pgi, clang]
+
   mpi:
     buildable: false
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.2%gcc@8.1.0 arch=linux-rhel7-broadwell
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.1.0
-    - spec: mvapich2@2.3%gcc@8.1.0 arch=linux-rhel7-broadwell
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
-    - spec: mvapich2@2.2%gcc@8.3.1 arch=linux-rhel7-broadwell
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.3.1
-    - spec: mvapich2@2.3%gcc@8.3.1 arch=linux-rhel7-broadwell
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.3.1
-    - spec: mvapich2@2.2%clang@10.0.0 arch=linux-rhel7-broadwell
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.2-clang-10.0.0
-    - spec: mvapich2@2.3%clang@10.0.0 arch=linux-rhel7-broadwell
+    - spec: mvapich2@2.3.1%clang@10.0.0~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0
+    - spec: mvapich2@2.3.1%clang@9.0.0~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0
+    - spec: mvapich2@2.3.1%pgi@19.7~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-pgi-19.7
+    - spec: mvapich2@2.3.1%pgi@20.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-pgi-20.1
+    - spec: mvapich2@2.3.1%intel@19.1.0.166~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.1.0
+    - spec: mvapich2@2.3.1%intel@18.0.2~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2
+    - spec: mvapich2@2.3.1%intel@17.0.2~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-17.0.2
+    - spec: mvapich2@2.3.1%gcc@8.1.0~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
+    - spec: mvapich2@2.3.1%gcc@4.9.3~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-4.9.3
   openmpi:
     buildable: false
     externals:
@@ -62,6 +82,63 @@ packages::
       prefix: /usr/tce/packages/openmpi/openmpi-2.1.0-clang-10.0.0
     - spec: openmpi@3.0.1%clang@10.0.0 arch=linux-rhel7-broadwell
       prefix: /usr/tce/packages/openmpi/openmpi-3.0.1-clang-10.0.0
+  cuda:
+    version: [10.1.168]
+    buildable: false
+    externals:
+    - spec: cuda@10.1.168
+      prefix: /usr/tce/packages/cuda/cuda-10.1.168
+  hip:
+    version: [4.0.0, 4.1.0, 4.2.0]
+    buildable: false
+    externals:
+    - spec: hip@4.0.0
+      prefix: /opt/rocm-4.0.0/hip
+    - spec: hip@4.1.0
+      prefix: /opt/rocm-4.1.0/hip
+    - spec: hip@4.2.0
+      prefix: /opt/rocm-4.2.0/hip
+  llvm-amdgpu:
+    version: [4.0.0, 4.1.0, 4.2.0]
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@4.0.0
+      prefix: /opt/rocm-4.0.0/llvm
+    - spec: llvm-amdgpu@4.1.0
+      prefix: /opt/rocm-4.1.0/llvm
+    - spec: llvm-amdgpu@4.2.0
+      prefix: /opt/rocm-4.2.0/llvm
+  hsa-rocr-dev:
+    version: [4.0.0, 4.1.0, 4.2.0]
+    buildable: false
+    externals:
+    - spec: hsa-rocr-dev@4.0.0
+      prefix: /opt/rocm-4.0.0/
+    - spec: hsa-rocr-dev@4.1.0
+      prefix: /opt/rocm-4.1.0/
+    - spec: hsa-rocr-dev@4.2.0
+      prefix: /opt/rocm-4.2.0/
+  rocminfo:
+    version: [4.0.0, 4.1.0, 4.2.0]
+    buildable: false
+    externals:
+    - spec: rocminfo@4.0.0
+      prefix: /opt/rocm-4.0.0/
+    - spec: rocminfo@4.1.0
+      prefix: /opt/rocm-4.1.0/
+    - spec: rocminfo@4.2.0
+      prefix: /opt/rocm-4.2.0/
+  rocm-device-libs:
+    version: [4.0.0, 4.1.0, 4.2.0]
+    buildable: false
+    externals:
+    - spec: rocm-device-libs@4.0.0
+      prefix: /opt/rocm-4.0.0/
+    - spec: rocm-device-libs@4.1.0
+      prefix: /opt/rocm-4.1.0/
+    - spec: rocm-device-libs@4.2.0
+      prefix: /opt/rocm-4.2.0/
+
   cmake:
     version:
     - 3.18.0


### PR DESCRIPTION
This is an attempt to merge the spack configuration with radiuss-spack-config one.

If this work out well, we should submit the change to radiuss-spack-config, and ultimately use it as a submodule to provide the configuration.

2 limitations:
- at the beginning of the packages config, there are permission and provider sections, we may want to place them in the spack.yaml.
- at the end on the packages config, there are all the external utilities we do not rebuild. We should decide if we want to keep those or not.